### PR TITLE
feat: add Toggle Outline button for .jl files

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,12 @@
         "command": "julia.toggleOutline",
         "category": "Julia",
         "title": "Toggle Outline",
-        "icon": "$(list-tree)"
+        "when": "editorLangId == julia",
+        "icon": "$(list-unordered)",
+        "actionBarOptions": {
+          "controlType": "button",
+          "displayTitle": false
+        }
       }
     ],
     "configuration": {
@@ -184,12 +189,13 @@
           "command": "julia.runSelection",
           "group": "navigation",
           "order": 2
-        },
+        }
+      ],
+      "editor/actions/left": [
         {
           "when": "resourceExtname == .jl || editorLangId == julia",
           "command": "julia.toggleOutline",
-          "group": "navigation",
-          "order": 3
+          "group": "navigation@45"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "positron-julia",
   "displayName": "Julia for Positron",
   "description": "Julia language support for Positron IDE",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "ntluong95",
   "license": "SEE LICENSE IN LICENSE",
   "private": false,
@@ -25,7 +25,8 @@
     "onCommand:julia.createNewFile",
     "onCommand:julia.selectInterpreter",
     "onCommand:julia.runFile",
-    "onCommand:julia.runSelection"
+    "onCommand:julia.runSelection",
+    "onCommand:julia.toggleOutline"
   ],
   "contributes": {
     "languageRuntimes": [
@@ -113,6 +114,12 @@
         "command": "julia.runSelection",
         "category": "Julia",
         "title": "Run Selection"
+      },
+      {
+        "command": "julia.toggleOutline",
+        "category": "Julia",
+        "title": "Toggle Outline",
+        "icon": "$(list-tree)"
       }
     ],
     "configuration": {
@@ -177,6 +184,12 @@
           "command": "julia.runSelection",
           "group": "navigation",
           "order": 2
+        },
+        {
+          "when": "resourceExtname == .jl || editorLangId == julia",
+          "command": "julia.toggleOutline",
+          "group": "navigation",
+          "order": 3
         }
       ]
     },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -12,6 +12,7 @@ import { LOGGER } from "./extension";
 const JULIA_LANGUAGE_ID = "julia";
 const JULIA_RUN_FILE_COMMAND = "julia.runFile";
 const JULIA_RUN_SELECTION_COMMAND = "julia.runSelection";
+const JULIA_TOGGLE_OUTLINE_COMMAND = "julia.toggleOutline";
 
 function isJuliaDocument(document: vscode.TextDocument): boolean {
   return document.languageId === JULIA_LANGUAGE_ID;
@@ -77,6 +78,8 @@ async function runSelection(editor: vscode.TextEditor): Promise<void> {
 
   await executeJuliaCode(code);
 }
+
+let outlineIsVisible = false;
 
 /**
  * Registers Julia-specific commands.
@@ -148,5 +151,18 @@ export function registerCommands(
       JULIA_RUN_SELECTION_COMMAND,
       runSelectionCommand,
     ),
+  );
+
+  // Toggle Outline panel (only the Outline, not the whole sidebar)
+  context.subscriptions.push(
+    vscode.commands.registerCommand(JULIA_TOGGLE_OUTLINE_COMMAND, async () => {
+      if (outlineIsVisible) {
+        await vscode.commands.executeCommand("outline.removeView");
+        outlineIsVisible = false;
+      } else {
+        await vscode.commands.executeCommand("outline.focus");
+        outlineIsVisible = true;
+      }
+    }),
   );
 }


### PR DESCRIPTION
## Summary

- Adds a **Toggle Outline** button (`$(list-tree)` icon) to the editor title bar for `.jl` files
- First click opens and focuses the Outline view in the Explorer pane; second click collapses/removes it
- Inspired by [positron-r-wizard#17](https://github.com/ntluong95/positron-r-wizard/pull/17)

## Implementation details

The toggle uses `outline.focus` and `outline.removeView` — the same built-in VS Code commands used by the R Wizard implementation. This correctly targets **only the Outline panel**, so the rest of the sidebar (File Explorer, etc.) is unaffected.

**Avoided wrong behavior:** using `workbench.action.toggleSidebarVisibility` would open/close the entire sidebar. The chosen commands operate on the Outline view specifically.

Changes:
- `src/commands.ts`: registers `julia.toggleOutline` command; tracks visibility with a boolean flag
- `package.json`: declares the command (with `list-tree` icon), adds activation event, adds menu entry under `editor/title/run` for `.jl` files at order 3

## Test plan

- [ ] Open a `.jl` file — confirm the `list-tree` icon appears in the editor title bar
- [ ] Click the button — confirm the Outline panel opens and receives focus; File Explorer and other sidebar panels remain unchanged
- [ ] Click again — confirm the Outline panel is removed; the rest of the sidebar stays open
- [ ] Verify the button does **not** appear for non-Julia files
- [ ] `npm run compile` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)